### PR TITLE
Improve type safety and remove the need for explicit destructor calls

### DIFF
--- a/examples/fsm-example-morse/fsm-example-morse.cc
+++ b/examples/fsm-example-morse/fsm-example-morse.cc
@@ -162,8 +162,6 @@ CoFSM::State transmitReadyState(CoFSM::FSM& fsm)
             // Take the string from the event data and store.
             event >> pString;
             message = std::move(*pString);
-            // String is not trivially destructible so destroy explicitly from the event data.
-            event.destroy(pString);
             symbolsSent = 0;
         }
         else if (event == "TransmissionReadyEvent") {

--- a/examples/fsm-example-morse/makefile
+++ b/examples/fsm-example-morse/makefile
@@ -4,16 +4,23 @@ CC = g++
 INCLUDE_DIR = ../../include
 
 # Compiler flag
-CPPFLAGS = -O2 --pedantic-errors --std=c++20 -Wall -Wextra -I$(INCLUDE_DIR)
+CPP_COMMON_FLAGS = --pedantic-errors --std=c++20 -Wall -Wextra -I$(INCLUDE_DIR)
+CPP_DEBUG_FLAGS = -g -fsanitize=address
+CPP_OPTIMIZATION_FLAGS = -O2
 
 # The build target (i.e. the name of the executable)
 TARGET = fsm-example-morse
 
+all: CPPFLAGS = $(CPP_OPTIMIZATION_FLAGS) $(CPP_COMMON_FLAGS)
 all: $(TARGET)
 
 # Use laptop's keyboard LEDs for demonstration. The binary must be run with "sudo ./fsm-example-morse"
 linux: EXTRAFLAGS = -DLINUX
+linux: CPPFLAGS = $(CPP_OPTIMIZATION_FLAGS) $(CPP_COMMON_FLAGS)
 linux: $(TARGET)
+
+debug: CPPFLAGS = $(CPP_DEBUG_FLAGS) $(CPP_COMMON_FLAGS)
+debug: $(TARGET)
 
 clean:
 	rm -f *.o $(TARGET)

--- a/examples/fsm-example-rgb/fsm-blue.cc
+++ b/examples/fsm-example-rgb/fsm-blue.cc
@@ -117,7 +117,6 @@ static CoFSM::State blueIdleState(FSM& fsm)
         {
             event >> pStop;     // Stop token is in the payload of the handover event.
             stopToken = std::move(*pStop);
-            event.destroy(pStop); // Explicit destruction needed because stop_token is not trivially destructible.
             iBlinksLeft = iNumberOfBlinks; // Do this many blinks before handing over to another FSM
             event.construct("StartBlinkEvent", iBlinkTimeMs); // iBlinkTimeMs piggybacks on "StartBlinkEvent"
         }

--- a/examples/fsm-example-rgb/fsm-green.cc
+++ b/examples/fsm-example-rgb/fsm-green.cc
@@ -117,7 +117,6 @@ static CoFSM::State greenIdleState(FSM& fsm)
         {
             event >> pStop;     // Stop token is in the payload of the handover event.
             stopToken = std::move(*pStop);
-            event.destroy(pStop); // Explicit destruction needed because stop_token is not trivially destructible.
             iBlinksLeft = iNumberOfBlinks; // Do this many blinks before handing over to another FSM
             event.construct("StartBlinkEvent", iBlinkTimeMs); // iBlinkTimeMs piggybacks on "StartBlinkEvent"
         }

--- a/examples/fsm-example-rgb/fsm-red.cc
+++ b/examples/fsm-example-rgb/fsm-red.cc
@@ -117,7 +117,6 @@ static CoFSM::State redIdleState(FSM& fsm)
         {
             event >> pStop;     // Stop token is in the payload of the handover event.
             stopToken = std::move(*pStop);
-            event.destroy(pStop); // Explicit destruction needed because stop_token is not trivially destructible.
             iBlinksLeft = iNumberOfBlinks; // Do this many blinks before handing over to another FSM
             event.construct("StartBlinkEvent", iBlinkTimeMs); // iBlinkTimeMs piggybacks on "StartBlinkEvent"
         }


### PR DESCRIPTION
1. Operator >> of Event is now type safe, meaning that "event >> pData;" throws if pData is not a pointer to the type of the object in event's storage.
2. Calling event.destroy(pData) to destroy the object in the storage is not required anymore. The object will be destructed automatically when the next object is constructed into the storage.